### PR TITLE
refactor: removed need for .Listable sub class of BaseFilter and removed .Listable classes from filters

### DIFF
--- a/OpenMTRDemo/Filters/BaseFilter.cs
+++ b/OpenMTRDemo/Filters/BaseFilter.cs
@@ -57,11 +57,11 @@ namespace OpenMTRDemo.Filters
         private void removeButton_Click(object sender, EventArgs e)
         {
             this.Dispose(true);
+            Editor.EnableMoveButtons();
         }
 
         private void moveButton_Click(object sender, EventArgs e)
-        {
-            try
+        {try
             {
                 var source = FiltersPanel.Controls;
                 var reorder = new List<Control>();
@@ -79,12 +79,18 @@ namespace OpenMTRDemo.Filters
                     source.RemoveAt(index);
                 }
                 source.AddRange(reorder.ToArray());
+                Editor.EnableMoveButtons();
             }
             catch (NullReferenceException)
             {
                 MessageBox.Show("The filter was not declared properly for this button to work.");
             }
-            catch (IndexOutOfRangeException) { }
+        }
+
+        public void EnableMoveButtons(int position)
+        {
+            moveUpButton.Enabled = (position == 0 || position == 2);
+            moveDownButton.Enabled = (position == 0 || position == 1);
         }
     }
 }

--- a/OpenMTRDemo/Filters/BaseFilter.cs
+++ b/OpenMTRDemo/Filters/BaseFilter.cs
@@ -23,7 +23,7 @@ namespace OpenMTRDemo.Filters
 
         public virtual BaseFilter Clone()
         {
-            return null;
+            throw new NotImplementedException();
         }
 
         public void SetLabel()
@@ -80,7 +80,10 @@ namespace OpenMTRDemo.Filters
                 }
                 source.AddRange(reorder.ToArray());
             }
-            catch (NullReferenceException) { }
+            catch (NullReferenceException)
+            {
+                MessageBox.Show("The filter was not declared properly for this button to work.");
+            }
             catch (IndexOutOfRangeException) { }
         }
     }

--- a/OpenMTRDemo/Filters/BaseFilter.cs
+++ b/OpenMTRDemo/Filters/BaseFilter.cs
@@ -12,6 +12,7 @@ namespace OpenMTRDemo.Filters
         public string FilterName;
         public ExpandedImageForm Editor;
         public FlowLayoutPanel FiltersPanel;
+        public string ListableName { get { return FilterName;  } }
 
         public BaseFilter()
         {
@@ -20,9 +21,9 @@ namespace OpenMTRDemo.Filters
 
         public virtual void ApplyFilter(Mat image) { }
 
-        public override string ToString()
+        public virtual BaseFilter Clone()
         {
-            return FilterName;
+            return null;
         }
 
         public void SetLabel()
@@ -81,18 +82,6 @@ namespace OpenMTRDemo.Filters
             }
             catch (NullReferenceException) { }
             catch (IndexOutOfRangeException) { }
-        }
-
-        public abstract class BaseFilterListable
-        {
-            public string Name;
-            public ExpandedImageForm Form;
-            public FlowLayoutPanel Panel;
-            public abstract BaseFilter Instance();
-            public override string ToString()
-            {
-                return Name;
-            }
         }
     }
 }

--- a/OpenMTRDemo/Filters/BaseFilter.resx
+++ b/OpenMTRDemo/Filters/BaseFilter.resx
@@ -120,4 +120,7 @@
   <metadata name="labelButtonToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="labelButtonToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/OpenMTRDemo/Filters/BnWFilter.cs
+++ b/OpenMTRDemo/Filters/BnWFilter.cs
@@ -23,19 +23,9 @@ namespace OpenMTRDemo.Filters
             }
         }
 
-        public class Listable : BaseFilterListable
+        public override BaseFilter Clone()
         {
-            public Listable(ExpandedImageForm form, FlowLayoutPanel panel)
-            {
-                Form = form;
-                Panel = panel;
-                Name = "Black and White";
-            }
-
-            public override BaseFilter Instance()
-            {
-                return new BnWFilter(Form, Panel);
-            }
+            return new BnWFilter(Editor, FiltersPanel);
         }
     }
 }

--- a/OpenMTRDemo/Filters/CannyFilter.cs
+++ b/OpenMTRDemo/Filters/CannyFilter.cs
@@ -44,19 +44,9 @@ namespace OpenMTRDemo.Filters
             Render();
         }
 
-        public class Listable : BaseFilterListable
+        public override BaseFilter Clone()
         {
-            public Listable(ExpandedImageForm form, FlowLayoutPanel panel)
-            {
-                Form = form;
-                Panel = panel;
-                Name = "Canny Filter";
-            }
-
-            public override BaseFilter Instance()
-            {
-                return new CannyFilter(Form, Panel);
-            }
+            return new CannyFilter(Editor, FiltersPanel);
         }
     }
 }

--- a/OpenMTRDemo/Filters/GaussianFilter.cs
+++ b/OpenMTRDemo/Filters/GaussianFilter.cs
@@ -25,19 +25,9 @@ namespace OpenMTRDemo.Filters
             Render();
         }
 
-        public class Listable : BaseFilterListable
+        public override BaseFilter Clone()
         {
-            public Listable(ExpandedImageForm form, FlowLayoutPanel panel)
-            {
-                Form = form;
-                Panel = panel;
-                Name = "Gaussian Blur";
-            }
-
-            public override BaseFilter Instance()
-            {
-                return new GaussianFilter(Form, Panel);
-            }
+            return new GaussianFilter(Editor, FiltersPanel);
         }
     }
 }

--- a/OpenMTRDemo/Filters/SobelFilter.cs
+++ b/OpenMTRDemo/Filters/SobelFilter.cs
@@ -20,19 +20,9 @@ namespace OpenMTRDemo.Filters
             Cv2.Sobel(image, image, MatType.CV_8U, xorder: 1, yorder: 0, ksize: -1);
         }
 
-        public class Listable : BaseFilterListable
+        public override BaseFilter Clone()
         {
-            public Listable(ExpandedImageForm form, FlowLayoutPanel panel)
-            {
-                Form = form;
-                Panel = panel;
-                Name = "Sobel Filter";
-            }
-
-            public override BaseFilter Instance()
-            {
-                return new SobelFilter(Form, Panel);
-            }
+            return new SobelFilter(Editor, FiltersPanel);
         }
     }
 }

--- a/OpenMTRDemo/Forms/ExpandedImageForm.cs
+++ b/OpenMTRDemo/Forms/ExpandedImageForm.cs
@@ -100,11 +100,38 @@ namespace OpenMTRDemo.Forms
         private void addFilterButton_Click(object sender, EventArgs e)
         {
             filtersFlowPanel.Controls.Add(((BaseFilter)filtersComboBox.SelectedItem).Clone());
+            EnableMoveButtons();
+        }
+
+        private void filtersComboBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            addFilterButton.Enabled = (filtersComboBox.SelectedIndex != -1);
         }
 
         public Mat returnImage()
         {
             return Image;
+        }
+
+        public void EnableMoveButtons()
+        {
+            var list = filtersFlowPanel.Controls;
+            if (list.Count > 0)
+            {
+                if (list.Count == 1)
+                {
+                    ((BaseFilter)list[0]).EnableMoveButtons(3);
+                }
+                else
+                {
+                    foreach (BaseFilter filter in list)
+                    {
+                        filter.EnableMoveButtons(0);
+                    }
+                    ((BaseFilter)list[0]).EnableMoveButtons(1);
+                    ((BaseFilter)list[list.Count - 1]).EnableMoveButtons(2);
+                }
+            }
         }
     }
 }

--- a/OpenMTRDemo/Forms/ExpandedImageForm.cs
+++ b/OpenMTRDemo/Forms/ExpandedImageForm.cs
@@ -29,11 +29,11 @@ namespace OpenMTRDemo.Forms
 
         private void LoadFilters()
         {
-            BaseFilter.BaseFilterListable[] filters = {
-                new BnWFilter.Listable(this, filtersFlowPanel),
-                new GaussianFilter.Listable(this, filtersFlowPanel),
-                new CannyFilter.Listable(this, filtersFlowPanel),
-                new SobelFilter.Listable(this, filtersFlowPanel)
+            BaseFilter[] filters = {
+                new BnWFilter(this, filtersFlowPanel),
+                new GaussianFilter(this, filtersFlowPanel),
+                new CannyFilter(this, filtersFlowPanel),
+                new SobelFilter(this, filtersFlowPanel)
             };
             filtersComboBox.Items.AddRange(filters);
         }
@@ -99,7 +99,7 @@ namespace OpenMTRDemo.Forms
 
         private void addFilterButton_Click(object sender, EventArgs e)
         {
-            filtersFlowPanel.Controls.Add(((BaseFilter.BaseFilterListable)filtersComboBox.SelectedItem).Instance());
+            filtersFlowPanel.Controls.Add(((BaseFilter)filtersComboBox.SelectedItem).Clone());
         }
 
         public Mat returnImage()

--- a/OpenMTRDemo/Forms/ExpandedImageForm.designer.cs
+++ b/OpenMTRDemo/Forms/ExpandedImageForm.designer.cs
@@ -49,10 +49,10 @@
             // 
             // OutputImageBox
             // 
-            this.OutputImageBox.Location = new System.Drawing.Point(0, 24);
-            this.OutputImageBox.Margin = new System.Windows.Forms.Padding(2);
+            this.OutputImageBox.Location = new System.Drawing.Point(0, 30);
+            this.OutputImageBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.OutputImageBox.Name = "OutputImageBox";
-            this.OutputImageBox.Size = new System.Drawing.Size(588, 441);
+            this.OutputImageBox.Size = new System.Drawing.Size(784, 543);
             this.OutputImageBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.OutputImageBox.TabIndex = 1;
             this.OutputImageBox.TabStop = false;
@@ -63,11 +63,11 @@
             this.tabPage3.Controls.Add(this.HeightTextBox);
             this.tabPage3.Controls.Add(this.label1);
             this.tabPage3.Controls.Add(this.WidthTextBox);
-            this.tabPage3.Location = new System.Drawing.Point(4, 22);
-            this.tabPage3.Margin = new System.Windows.Forms.Padding(2);
+            this.tabPage3.Location = new System.Drawing.Point(4, 25);
+            this.tabPage3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPage3.Name = "tabPage3";
-            this.tabPage3.Padding = new System.Windows.Forms.Padding(2);
-            this.tabPage3.Size = new System.Drawing.Size(248, 370);
+            this.tabPage3.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tabPage3.Size = new System.Drawing.Size(333, 458);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Properties";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -75,9 +75,10 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(5, 27);
+            this.label2.Location = new System.Drawing.Point(7, 33);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(41, 13);
+            this.label2.Size = new System.Drawing.Size(53, 17);
             this.label2.TabIndex = 3;
             this.label2.Text = "Height:";
             // 
@@ -85,18 +86,20 @@
             // 
             this.HeightTextBox.BackColor = System.Drawing.Color.White;
             this.HeightTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.HeightTextBox.Location = new System.Drawing.Point(52, 27);
+            this.HeightTextBox.Location = new System.Drawing.Point(69, 33);
+            this.HeightTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.HeightTextBox.Name = "HeightTextBox";
             this.HeightTextBox.ReadOnly = true;
-            this.HeightTextBox.Size = new System.Drawing.Size(125, 13);
+            this.HeightTextBox.Size = new System.Drawing.Size(167, 15);
             this.HeightTextBox.TabIndex = 2;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(8, 14);
+            this.label1.Location = new System.Drawing.Point(11, 17);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(38, 13);
+            this.label1.Size = new System.Drawing.Size(48, 17);
             this.label1.TabIndex = 1;
             this.label1.Text = "Width:";
             // 
@@ -104,10 +107,11 @@
             // 
             this.WidthTextBox.BackColor = System.Drawing.Color.White;
             this.WidthTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.WidthTextBox.Location = new System.Drawing.Point(52, 14);
+            this.WidthTextBox.Location = new System.Drawing.Point(69, 17);
+            this.WidthTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.WidthTextBox.Name = "WidthTextBox";
             this.WidthTextBox.ReadOnly = true;
-            this.WidthTextBox.Size = new System.Drawing.Size(125, 13);
+            this.WidthTextBox.Size = new System.Drawing.Size(167, 15);
             this.WidthTextBox.TabIndex = 0;
             // 
             // tabPage1
@@ -115,27 +119,30 @@
             this.tabPage1.Controls.Add(this.filtersComboBox);
             this.tabPage1.Controls.Add(this.addFilterButton);
             this.tabPage1.Controls.Add(this.filtersFlowPanel);
-            this.tabPage1.Location = new System.Drawing.Point(4, 22);
+            this.tabPage1.Location = new System.Drawing.Point(4, 25);
             this.tabPage1.Margin = new System.Windows.Forms.Padding(0);
             this.tabPage1.Name = "tabPage1";
-            this.tabPage1.Size = new System.Drawing.Size(248, 370);
+            this.tabPage1.Size = new System.Drawing.Size(333, 458);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Filters";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
             // filtersComboBox
             // 
+            this.filtersComboBox.DisplayMember = "ListableName";
             this.filtersComboBox.FormattingEnabled = true;
-            this.filtersComboBox.Location = new System.Drawing.Point(3, 4);
+            this.filtersComboBox.Location = new System.Drawing.Point(4, 5);
+            this.filtersComboBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.filtersComboBox.Name = "filtersComboBox";
-            this.filtersComboBox.Size = new System.Drawing.Size(159, 21);
+            this.filtersComboBox.Size = new System.Drawing.Size(211, 24);
             this.filtersComboBox.TabIndex = 4;
             // 
             // addFilterButton
             // 
-            this.addFilterButton.Location = new System.Drawing.Point(168, 4);
+            this.addFilterButton.Location = new System.Drawing.Point(224, 5);
+            this.addFilterButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.addFilterButton.Name = "addFilterButton";
-            this.addFilterButton.Size = new System.Drawing.Size(75, 21);
+            this.addFilterButton.Size = new System.Drawing.Size(100, 26);
             this.addFilterButton.TabIndex = 3;
             this.addFilterButton.Text = "Add";
             this.addFilterButton.UseVisualStyleBackColor = true;
@@ -144,9 +151,10 @@
             // filtersFlowPanel
             // 
             this.filtersFlowPanel.AutoScroll = true;
-            this.filtersFlowPanel.Location = new System.Drawing.Point(0, 31);
+            this.filtersFlowPanel.Location = new System.Drawing.Point(0, 38);
+            this.filtersFlowPanel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.filtersFlowPanel.Name = "filtersFlowPanel";
-            this.filtersFlowPanel.Size = new System.Drawing.Size(248, 339);
+            this.filtersFlowPanel.Size = new System.Drawing.Size(331, 417);
             this.filtersFlowPanel.TabIndex = 1;
             this.filtersFlowPanel.ControlAdded += new System.Windows.Forms.ControlEventHandler(this.Render);
             this.filtersFlowPanel.ControlRemoved += new System.Windows.Forms.ControlEventHandler(this.Render);
@@ -155,19 +163,19 @@
             // 
             this.tabControl1.Controls.Add(this.tabPage1);
             this.tabControl1.Controls.Add(this.tabPage3);
-            this.tabControl1.Location = new System.Drawing.Point(592, 26);
-            this.tabControl1.Margin = new System.Windows.Forms.Padding(2);
+            this.tabControl1.Location = new System.Drawing.Point(789, 32);
+            this.tabControl1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(256, 396);
+            this.tabControl1.Size = new System.Drawing.Size(341, 487);
             this.tabControl1.TabIndex = 3;
             // 
             // cancelButton
             // 
-            this.cancelButton.Location = new System.Drawing.Point(688, 429);
-            this.cancelButton.Margin = new System.Windows.Forms.Padding(2);
+            this.cancelButton.Location = new System.Drawing.Point(917, 528);
+            this.cancelButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(76, 28);
+            this.cancelButton.Size = new System.Drawing.Size(101, 34);
             this.cancelButton.TabIndex = 5;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
@@ -175,10 +183,10 @@
             // 
             // okButton
             // 
-            this.okButton.Location = new System.Drawing.Point(768, 429);
-            this.okButton.Margin = new System.Windows.Forms.Padding(2);
+            this.okButton.Location = new System.Drawing.Point(1024, 528);
+            this.okButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(76, 28);
+            this.okButton.Size = new System.Drawing.Size(101, 34);
             this.okButton.TabIndex = 6;
             this.okButton.Text = "OK";
             this.okButton.UseVisualStyleBackColor = true;
@@ -186,15 +194,15 @@
             // 
             // ExpandedImageForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(851, 465);
+            this.ClientSize = new System.Drawing.Size(1135, 572);
             this.Controls.Add(this.okButton);
             this.Controls.Add(this.cancelButton);
             this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.OutputImageBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "ExpandedImageForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "OpenMTR Demo";

--- a/OpenMTRDemo/Forms/ExpandedImageForm.designer.cs
+++ b/OpenMTRDemo/Forms/ExpandedImageForm.designer.cs
@@ -49,10 +49,10 @@
             // 
             // OutputImageBox
             // 
-            this.OutputImageBox.Location = new System.Drawing.Point(0, 30);
-            this.OutputImageBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.OutputImageBox.Location = new System.Drawing.Point(0, 24);
+            this.OutputImageBox.Margin = new System.Windows.Forms.Padding(2);
             this.OutputImageBox.Name = "OutputImageBox";
-            this.OutputImageBox.Size = new System.Drawing.Size(784, 543);
+            this.OutputImageBox.Size = new System.Drawing.Size(588, 441);
             this.OutputImageBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.OutputImageBox.TabIndex = 1;
             this.OutputImageBox.TabStop = false;
@@ -63,11 +63,11 @@
             this.tabPage3.Controls.Add(this.HeightTextBox);
             this.tabPage3.Controls.Add(this.label1);
             this.tabPage3.Controls.Add(this.WidthTextBox);
-            this.tabPage3.Location = new System.Drawing.Point(4, 25);
-            this.tabPage3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tabPage3.Location = new System.Drawing.Point(4, 22);
+            this.tabPage3.Margin = new System.Windows.Forms.Padding(2);
             this.tabPage3.Name = "tabPage3";
-            this.tabPage3.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPage3.Size = new System.Drawing.Size(333, 458);
+            this.tabPage3.Padding = new System.Windows.Forms.Padding(2);
+            this.tabPage3.Size = new System.Drawing.Size(248, 370);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Properties";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -75,10 +75,9 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(7, 33);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(5, 27);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(53, 17);
+            this.label2.Size = new System.Drawing.Size(41, 13);
             this.label2.TabIndex = 3;
             this.label2.Text = "Height:";
             // 
@@ -86,20 +85,18 @@
             // 
             this.HeightTextBox.BackColor = System.Drawing.Color.White;
             this.HeightTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.HeightTextBox.Location = new System.Drawing.Point(69, 33);
-            this.HeightTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.HeightTextBox.Location = new System.Drawing.Point(52, 27);
             this.HeightTextBox.Name = "HeightTextBox";
             this.HeightTextBox.ReadOnly = true;
-            this.HeightTextBox.Size = new System.Drawing.Size(167, 15);
+            this.HeightTextBox.Size = new System.Drawing.Size(125, 13);
             this.HeightTextBox.TabIndex = 2;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(11, 17);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(8, 14);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(48, 17);
+            this.label1.Size = new System.Drawing.Size(38, 13);
             this.label1.TabIndex = 1;
             this.label1.Text = "Width:";
             // 
@@ -107,11 +104,10 @@
             // 
             this.WidthTextBox.BackColor = System.Drawing.Color.White;
             this.WidthTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.WidthTextBox.Location = new System.Drawing.Point(69, 17);
-            this.WidthTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.WidthTextBox.Location = new System.Drawing.Point(52, 14);
             this.WidthTextBox.Name = "WidthTextBox";
             this.WidthTextBox.ReadOnly = true;
-            this.WidthTextBox.Size = new System.Drawing.Size(167, 15);
+            this.WidthTextBox.Size = new System.Drawing.Size(125, 13);
             this.WidthTextBox.TabIndex = 0;
             // 
             // tabPage1
@@ -119,10 +115,10 @@
             this.tabPage1.Controls.Add(this.filtersComboBox);
             this.tabPage1.Controls.Add(this.addFilterButton);
             this.tabPage1.Controls.Add(this.filtersFlowPanel);
-            this.tabPage1.Location = new System.Drawing.Point(4, 25);
+            this.tabPage1.Location = new System.Drawing.Point(4, 22);
             this.tabPage1.Margin = new System.Windows.Forms.Padding(0);
             this.tabPage1.Name = "tabPage1";
-            this.tabPage1.Size = new System.Drawing.Size(333, 458);
+            this.tabPage1.Size = new System.Drawing.Size(248, 370);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Filters";
             this.tabPage1.UseVisualStyleBackColor = true;
@@ -131,18 +127,18 @@
             // 
             this.filtersComboBox.DisplayMember = "ListableName";
             this.filtersComboBox.FormattingEnabled = true;
-            this.filtersComboBox.Location = new System.Drawing.Point(4, 5);
-            this.filtersComboBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.filtersComboBox.Location = new System.Drawing.Point(3, 4);
             this.filtersComboBox.Name = "filtersComboBox";
-            this.filtersComboBox.Size = new System.Drawing.Size(211, 24);
+            this.filtersComboBox.Size = new System.Drawing.Size(159, 21);
             this.filtersComboBox.TabIndex = 4;
+            this.filtersComboBox.SelectedIndexChanged += new System.EventHandler(this.filtersComboBox_SelectedIndexChanged);
             // 
             // addFilterButton
             // 
-            this.addFilterButton.Location = new System.Drawing.Point(224, 5);
-            this.addFilterButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.addFilterButton.Enabled = false;
+            this.addFilterButton.Location = new System.Drawing.Point(168, 4);
             this.addFilterButton.Name = "addFilterButton";
-            this.addFilterButton.Size = new System.Drawing.Size(100, 26);
+            this.addFilterButton.Size = new System.Drawing.Size(75, 21);
             this.addFilterButton.TabIndex = 3;
             this.addFilterButton.Text = "Add";
             this.addFilterButton.UseVisualStyleBackColor = true;
@@ -151,10 +147,9 @@
             // filtersFlowPanel
             // 
             this.filtersFlowPanel.AutoScroll = true;
-            this.filtersFlowPanel.Location = new System.Drawing.Point(0, 38);
-            this.filtersFlowPanel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.filtersFlowPanel.Location = new System.Drawing.Point(0, 31);
             this.filtersFlowPanel.Name = "filtersFlowPanel";
-            this.filtersFlowPanel.Size = new System.Drawing.Size(331, 417);
+            this.filtersFlowPanel.Size = new System.Drawing.Size(248, 339);
             this.filtersFlowPanel.TabIndex = 1;
             this.filtersFlowPanel.ControlAdded += new System.Windows.Forms.ControlEventHandler(this.Render);
             this.filtersFlowPanel.ControlRemoved += new System.Windows.Forms.ControlEventHandler(this.Render);
@@ -163,19 +158,19 @@
             // 
             this.tabControl1.Controls.Add(this.tabPage1);
             this.tabControl1.Controls.Add(this.tabPage3);
-            this.tabControl1.Location = new System.Drawing.Point(789, 32);
-            this.tabControl1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tabControl1.Location = new System.Drawing.Point(592, 26);
+            this.tabControl1.Margin = new System.Windows.Forms.Padding(2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(341, 487);
+            this.tabControl1.Size = new System.Drawing.Size(256, 396);
             this.tabControl1.TabIndex = 3;
             // 
             // cancelButton
             // 
-            this.cancelButton.Location = new System.Drawing.Point(917, 528);
-            this.cancelButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.cancelButton.Location = new System.Drawing.Point(688, 429);
+            this.cancelButton.Margin = new System.Windows.Forms.Padding(2);
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(101, 34);
+            this.cancelButton.Size = new System.Drawing.Size(76, 28);
             this.cancelButton.TabIndex = 5;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
@@ -183,10 +178,10 @@
             // 
             // okButton
             // 
-            this.okButton.Location = new System.Drawing.Point(1024, 528);
-            this.okButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.okButton.Location = new System.Drawing.Point(768, 429);
+            this.okButton.Margin = new System.Windows.Forms.Padding(2);
             this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(101, 34);
+            this.okButton.Size = new System.Drawing.Size(76, 28);
             this.okButton.TabIndex = 6;
             this.okButton.Text = "OK";
             this.okButton.UseVisualStyleBackColor = true;
@@ -194,15 +189,15 @@
             // 
             // ExpandedImageForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1135, 572);
+            this.ClientSize = new System.Drawing.Size(851, 465);
             this.Controls.Add(this.okButton);
             this.Controls.Add(this.cancelButton);
             this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.OutputImageBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
-            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "ExpandedImageForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "OpenMTR Demo";


### PR DESCRIPTION
Originally the combobox (and list boxes for that matter) displayed nothing whenever I put a control object in them instead of some other general object. My slightly janky solution was to create a class in each filter that was added instead until I could find a more permanent and elegant solution. I have done some research and found that solution, this is it.